### PR TITLE
Add Warehouses object and adjust method on stock

### DIFF
--- a/lib/shipwire.rb
+++ b/lib/shipwire.rb
@@ -5,6 +5,7 @@ require 'recursive_open_struct'
 
 require 'shipwire/version'
 require 'shipwire/api'
+require 'shipwire/api_v31'
 require 'shipwire/configuration'
 require 'shipwire/param_converter'
 require 'shipwire/request'

--- a/lib/shipwire.rb
+++ b/lib/shipwire.rb
@@ -21,6 +21,7 @@ require 'shipwire/returns'
 require 'shipwire/secret'
 require 'shipwire/stock'
 require 'shipwire/webhooks'
+require 'shipwire/warehouses'
 
 require 'shipwire/products/base'
 require 'shipwire/products/insert'

--- a/lib/shipwire/api.rb
+++ b/lib/shipwire/api.rb
@@ -1,7 +1,17 @@
 module Shipwire
   class Api
     def request(method, path, body: {}, params: {})
-      Request.send(method: method, path: path, body: body, params: params)
+      Request.send(method: method, path: full_path(path), body: body, params: params)
+    end
+
+    private
+
+    def api_version
+      'v3'
+    end
+
+    def full_path(path)
+      "#{api_version}/#{path}"
     end
   end
 end

--- a/lib/shipwire/api_v31.rb
+++ b/lib/shipwire/api_v31.rb
@@ -1,0 +1,9 @@
+module Shipwire
+  class ApiV31 < Api
+    private
+
+    def api_version
+      'v3.1'
+    end
+  end
+end

--- a/lib/shipwire/request.rb
+++ b/lib/shipwire/request.rb
@@ -4,8 +4,6 @@ module Shipwire
       new(**args).send
     end
 
-    API_VERSION = 3
-
     attr_reader :method, :path, :params, :body
 
     def initialize(method: :get, path: '', params: {}, body: {})
@@ -55,7 +53,7 @@ module Shipwire
     end
 
     def full_path
-      "/api/v#{API_VERSION}/#{@path}"
+      "/api/#{@path}"
     end
 
     def params

--- a/lib/shipwire/stock.rb
+++ b/lib/shipwire/stock.rb
@@ -3,5 +3,9 @@ module Shipwire
     def list(params = {})
       request(:get, 'stock', params: params)
     end
+
+    def adjust(body = {})
+      request(:post, 'stock/adjust', body: body)
+    end
   end
 end

--- a/lib/shipwire/warehouses.rb
+++ b/lib/shipwire/warehouses.rb
@@ -1,0 +1,19 @@
+module Shipwire
+  class Warehouses < ApiV31
+    def list(params = {})
+      request(:get, 'warehouses', params: params)
+    end
+
+    def create(body)
+      request(:post, 'warehouses', body: body)
+    end
+
+    def find(id, params = {})
+      request(:get, "warehouses/#{id}", params: params)
+    end
+
+    def update(id, body, params = {})
+      request(:put, "warehouses/#{id}", body: body, params: params)
+    end
+  end
+end


### PR DESCRIPTION
Warehouses API are provided by the new shipwire API version. The current object doesn't allow to
use the V3.1 I changed the full_path method and created a new ApiV31 class to use it.